### PR TITLE
Intercept and print compile errors in a nicer way.

### DIFF
--- a/lib/display.ex
+++ b/lib/display.ex
@@ -24,6 +24,11 @@ defmodule Display do
     "Assertion failed in #{source_file(module)}:#{line_number(expr)}"
   end
 
+  def format_compile_error(error) do
+    trace = System.stacktrace |> Enum.take(2)
+    IO.puts(format_red(Exception.format(:error, error, trace)))
+  end
+
   defp line_number({_, [line: line], _}) do
     line
   end

--- a/lib/watcher.ex
+++ b/lib/watcher.ex
@@ -3,8 +3,12 @@ defmodule Watcher do
 
   def callback(file, events)  do
     if Enum.member?(events, :modified) do
-      [{mod, _}] = Code.load_file(file)
-      Runner.run(mod)
+      try do
+        [{mod, _}] = Code.load_file(file)
+        Runner.run(mod)
+      rescue
+        e -> Display.format_compile_error(e)
+      end
     end
   end
 end


### PR DESCRIPTION
This PR changes the error formatting for compiler errors:
  * Only print the first two lines of the stacktrace to hide the runner internals from the trace.
  * It doesn't print the message about workers shutting down. That message is not useful to users.

Closes #4 