### PR TITLE
Format runtime errors consistently with assertion errors

### DIFF
--- a/lib/display.ex
+++ b/lib/display.ex
@@ -11,18 +11,8 @@ defmodule Display do
     IO.puts(format_failure(failure))
   end
 
-  def format_failure(%ExUnit.AssertionError{expr: expr}) do
-    """
-    #{format_cyan("Assertion failed in #{last_failure_location}")}
-    #{format_red(Macro.to_string(expr))}
-    """
-  end
-
-  def format_failure(error) do
-    """
-    #{format_cyan("Error in #{last_failure_location}")}
-    #{format_error(error)}
-    """
+  def show_compile_error(error) do
+    format_error(error) |> IO.puts
   end
 
   def considering(module) do
@@ -36,7 +26,21 @@ defmodule Display do
     end
   end
 
-  def last_failure_location do
+  defp format_failure(%ExUnit.AssertionError{expr: expr}) do
+    """
+    #{format_cyan("Assertion failed in #{last_failure_location}")}
+    #{format_red(Macro.to_string(expr))}
+    """
+  end
+
+  defp format_failure(error) do
+    """
+    #{format_cyan("Error in #{last_failure_location}")}
+    #{format_error(error)}
+    """
+  end
+
+  defp last_failure_location do
     {file, line} = System.stacktrace
       |> Enum.drop_while(&in_ex_unit?/1)
       |> List.first
@@ -52,11 +56,7 @@ defmodule Display do
     {file, line}
   end
 
-  def format_compile_error(error) do
-    format_error(error) |> IO.puts
-  end
-
-  def format_error(error) do
+  defp format_error(error) do
     trace = System.stacktrace |> Enum.take(2)
     format_red(Exception.format(:error, error, trace))
   end

--- a/lib/display.ex
+++ b/lib/display.ex
@@ -2,18 +2,31 @@ defmodule Display do
   alias IO.ANSI
   @current_dir File.cwd!
 
-  def show_failure(%{expr: expr}, module, name) do
+  def show_failure(failure, module, name) do
     clear_screen()
 
-    IO.puts("Now meditate upon #{display_module(module)}")
+    IO.puts("Now meditate upon #{format_module(module)}")
     IO.puts("---------------------------------------")
-    IO.puts(format_cyan(last_failure_location))
     IO.puts(name)
-    IO.puts(format_red(Macro.to_string(expr)))
+    IO.puts(format_failure(failure))
+  end
+
+  def format_failure(%ExUnit.AssertionError{expr: expr}) do
+    """
+    #{format_cyan("Assertion failed in #{last_failure_location}")}
+    #{format_red(Macro.to_string(expr))}
+    """
+  end
+
+  def format_failure(error) do
+    """
+    #{format_cyan("Error in #{last_failure_location}")}
+    #{format_error(error)}
+    """
   end
 
   def considering(module) do
-    IO.puts("Considering #{display_module(module)}...")
+    IO.puts("Considering #{format_module(module)}...")
   end
 
   def clear_screen() do
@@ -29,7 +42,7 @@ defmodule Display do
       |> List.first
       |> extract_file_and_line
 
-    "Assertion failed in #{file}:#{line}"
+    "#{file}:#{line}"
   end
 
   defp in_ex_unit?({ExUnit.Assertions, _, _, _}), do: true
@@ -40,8 +53,12 @@ defmodule Display do
   end
 
   def format_compile_error(error) do
+    format_error(error) |> IO.puts
+  end
+
+  def format_error(error) do
     trace = System.stacktrace |> Enum.take(2)
-    IO.puts(format_red(Exception.format(:error, error, trace)))
+    format_red(Exception.format(:error, error, trace))
   end
 
   defp format_red(str) do
@@ -52,7 +69,7 @@ defmodule Display do
     Enum.join([ANSI.cyan, str, ANSI.reset], "")
   end
 
-  defp display_module(module) do
+  defp format_module(module) do
     Module.split(module) |> List.last
   end
 end

--- a/lib/display.ex
+++ b/lib/display.ex
@@ -12,6 +12,7 @@ defmodule Display do
   end
 
   def show_compile_error(error) do
+    IO.puts("")
     format_error(error) |> IO.puts
   end
 

--- a/lib/koans.ex
+++ b/lib/koans.ex
@@ -8,7 +8,7 @@ defmodule Koans do
           unquote(body)
           :ok
         rescue
-          e in ExUnit.AssertionError -> e
+          e in _ -> e
         end
       end
     end

--- a/lib/watcher.ex
+++ b/lib/watcher.ex
@@ -7,7 +7,7 @@ defmodule Watcher do
         [{mod, _} | _] = Code.load_file(file)
         Runner.run(mod)
       rescue
-        e -> Display.format_compile_error(e)
+        e -> Display.show_compile_error(e)
       end
     end
   end


### PR DESCRIPTION
Tried to get a consistent look to assertion errors and runtime errors.

<img width="1050" alt="screen shot 2016-03-08 at 15 30 36" src="https://cloud.githubusercontent.com/assets/3731516/13603041/11738b80-e543-11e5-9ed1-b96a0d26d8a7.png">


cc @felipesere 
closes #30