### PR TITLE
Force koan order using macros and attributes

### DIFF
--- a/lib/display.ex
+++ b/lib/display.ex
@@ -8,7 +8,7 @@ defmodule Display do
     IO.puts("Now meditate upon #{display_module(module)}")
     IO.puts("---------------------------------------")
     IO.puts(format_cyan(last_failure_location))
-    IO.puts(display_koan(name))
+    IO.puts(name)
     IO.puts(format_red(Macro.to_string(expr)))
   end
 
@@ -54,9 +54,5 @@ defmodule Display do
 
   defp display_module(module) do
     Module.split(module) |> List.last
-  end
-
-  defp display_koan(name) do
-    String.replace(to_string(name), Koans.prefix, "")
   end
 end

--- a/lib/koans.ex
+++ b/lib/koans.ex
@@ -1,9 +1,6 @@
 defmodule Koans do
-  @prefix "koan: "
-
   defmacro koan(name, body) do
-    compiled_name = :"#{prefix}#{name}"
-
+    compiled_name = String.to_atom(name)
     quote do
       @koans unquote(compiled_name)
       def unquote(compiled_name)() do
@@ -24,16 +21,10 @@ defmodule Koans do
       import Koans
       import BlankAssertions
 
-      @before_compile KoansBuilder
+      @before_compile Koans
     end
   end
 
-  def prefix do
-    @prefix
-  end
-end
-
-defmodule KoansBuilder do
   defmacro __before_compile__(env) do
     koans = Module.get_attribute(env.module, :koans) |> Enum.reverse
     quote do

--- a/lib/koans.ex
+++ b/lib/koans.ex
@@ -3,7 +3,9 @@ defmodule Koans do
 
   defmacro koan(name, body) do
     compiled_name = :"#{prefix}#{name}"
+
     quote do
+      @koans unquote(compiled_name)
       def unquote(compiled_name)() do
         try do
           unquote(body)
@@ -17,13 +19,27 @@ defmodule Koans do
 
   defmacro __using__(opts) do
     quote do
+      Module.register_attribute(__MODULE__, :koans, accumulate: true)
       require ExUnit.Assertions
       import Koans
       import BlankAssertions
+
+      @before_compile KoansBuilder
     end
   end
 
   def prefix do
     @prefix
+  end
+end
+
+defmodule KoansBuilder do
+  defmacro __before_compile__(env) do
+    koans = Module.get_attribute(env.module, :koans) |> Enum.reverse
+    quote do
+      def all_koans do
+        unquote(koans)
+      end
+    end
   end
 end

--- a/lib/runner.ex
+++ b/lib/runner.ex
@@ -51,8 +51,7 @@ defmodule Runner do
   end
 
   defp extract_koans_from(module) do
-    module.__info__(:functions)
-    |> Enum.map(fn({name, _arity}) -> name end)
+    module.all_koans
     |> Enum.filter(&koan?/1)
   end
 

--- a/lib/runner.ex
+++ b/lib/runner.ex
@@ -28,8 +28,7 @@ defmodule Runner do
   def run_module(module) do
     Display.considering(module)
 
-    koans = extract_koans_from(module)
-
+    koans = module.all_koans
     passed = Enum.take_while(koans, fn(name) ->
       run_koan(module, name) == :passed
     end)
@@ -48,14 +47,5 @@ defmodule Runner do
         Display.show_failure(error, module, name)
         :failed
     end
-  end
-
-  defp extract_koans_from(module) do
-    module.all_koans
-    |> Enum.filter(&koan?/1)
-  end
-
-  defp koan?(fun_name) do
-    String.starts_with?(to_string(fun_name), Koans.prefix)
   end
 end


### PR DESCRIPTION
Inspired by plug.
This works by `accumulating` the name of each koan into an attribute and
then defining a new function `all_koans` that returns that list.

When meditating we use `all_koans` instead of `module.__info__(:functions)`.