### PR TITLE
Introduce --koan=<name> to run a specific koan module.

### DIFF
--- a/lib/display.ex
+++ b/lib/display.ex
@@ -2,6 +2,23 @@ defmodule Display do
   alias IO.ANSI
   @current_dir File.cwd!
 
+  def invalid_koan(koan, modules) do
+    koans_names = module_names(modules)
+    IO.puts("Did not find koan #{name(koan)} in " <> koans_names )
+    exit(:normal)
+  end
+
+  defp module_names(modules) do
+    modules
+    |> Enum.map(&Atom.to_string/1)
+    |> Enum.map(&name/1)
+    |> Enum.join(", ")
+    |> format_red
+  end
+
+  defp name("Elixir." <> module), do: module
+  defp name(module), do: name(Atom.to_string(module))
+
   def show_failure(failure, module, name) do
     IO.puts("Now meditate upon #{format_module(module)}")
     IO.puts("---------------------------------------")

--- a/lib/options.ex
+++ b/lib/options.ex
@@ -1,6 +1,7 @@
 defmodule Options do
   @defaults %{
-    clear_screen: false
+    clear_screen: false,
+    initial_koan: Equalities,
   }
 
   def start(args) do
@@ -13,12 +14,19 @@ defmodule Options do
     end)
   end
 
+  def initial_koan() do
+    Agent.get(__MODULE__, fn(options) ->
+      Map.fetch!(options, :initial_koan)
+    end)
+  end
+
   defp parse(args) do
     Enum.reduce(args, @defaults, fn(arg, acc) ->
       Map.merge(acc, parse_argument(arg))
     end)
   end
 
+  def parse_argument("--koan="<>module), do: %{ initial_koan: String.to_atom("Elixir."<> module)}
   def parse_argument("--clear-screen"), do: %{ clear_screen: true}
   def parse_argument(_), do: %{}
 end

--- a/lib/runner.ex
+++ b/lib/runner.ex
@@ -15,10 +15,11 @@ defmodule Runner do
   ]
 
   def run do
-    run(Equalities)
+    Options.initial_koan
+    |>run
   end
 
-  def run(start_module) do
+  def run(start_module) when start_module in @modules do
     Display.clear_screen()
     start_idx = Enum.find_index(@modules, &(&1 == start_module))
     Enum.drop(@modules, start_idx)
@@ -26,6 +27,7 @@ defmodule Runner do
       run_module(mod) == :passed
     end)
   end
+  def run(koan), do: Display.invalid_koan(koan, @modules)
 
   def run_module(module) do
     Display.considering(module)

--- a/test/options_test.exs
+++ b/test/options_test.exs
@@ -11,6 +11,11 @@ defmodule OptionTest do
     assert Options.clear_screen?
   end
 
+  test "can target specifc koans" do
+    Options.start(["--koan=Strings"])
+    assert Options.initial_koan() == Strings
+  end
+
   test "ignores unknown options" do
     Options.start(["--foo"])
     refute Options.clear_screen?


### PR DESCRIPTION
The default is still to run `Equalities`.

If the name of the module is not known, an error and possible modules are shown in red:

<img width="1070" alt="screen shot 2016-04-04 at 20 58 59" src="https://cloud.githubusercontent.com/assets/1850188/14261373/308cd204-faa8-11e5-8412-1a9e11cff06d.png">

@Maikon @ukutaht 