### PR TITLE
Koan per process

### DIFF
--- a/lib/display.ex
+++ b/lib/display.ex
@@ -33,6 +33,7 @@ defmodule Display do
 
   def considering(module) do
     IO.puts("Considering #{format_module(module)}...")
+    module
   end
 
   def clear_screen do

--- a/lib/display.ex
+++ b/lib/display.ex
@@ -42,34 +42,18 @@ defmodule Display do
     end
   end
 
-  defp format_failure(%ExUnit.AssertionError{expr: expr}) do
+  defp format_failure(%{error: %ExUnit.AssertionError{expr: expr}, file: file, line: line}) do
     """
-    #{format_cyan("Assertion failed in #{last_failure_location}")}
+    #{format_cyan("Assertion failed in #{file}:#{line}")}
     #{format_red(Macro.to_string(expr))}
     """
   end
 
-  defp format_failure(error) do
+  defp format_failure(%{error: error, file: file, line: line}) do
     """
-    #{format_cyan("Error in #{last_failure_location}")}
+    #{format_cyan("Error in #{file}:#{line}")}
     #{format_error(error)}
     """
-  end
-
-  defp last_failure_location do
-    {file, line} = System.stacktrace
-      |> Enum.drop_while(&in_ex_unit?/1)
-      |> List.first
-      |> extract_file_and_line
-
-    "#{file}:#{line}"
-  end
-
-  defp in_ex_unit?({ExUnit.Assertions, _, _, _}), do: true
-  defp in_ex_unit?(_), do: false
-
-  defp extract_file_and_line({_, _, _, [file: file, line: line]}) do
-    {file, line}
   end
 
   defp format_error(error) do

--- a/lib/execute.ex
+++ b/lib/execute.ex
@@ -1,36 +1,32 @@
 defmodule Execute do
   def run_module(module) do
-    run_until_failure(module, &run_koan/2)
-  end
-
-  def run_until_failure(module, callback) do
-    Enum.reduce_while(module.all_koans, :passed, fn(it, _acc) ->
-      result = callback.(module, it)
-      if result == :passed do
-        {:cont, :passed}
-      else
-        {:halt, result}
-      end
+    Enum.reduce_while(module.all_koans, :passed, fn(koan, _) ->
+      module
+      |> run_koan(koan)
+      |> continue?
     end)
   end
 
+  defp continue?(:passed), do: {:cont, :passed}
+  defp continue?(result), do: {:halt, result}
+
   def run_koan(module, name, args \\ []) do
     parent = self()
-    spawn fn -> exec(module, name, args, parent) end
+    spawn(fn -> exec(module, name, args, parent) end)
     receive do
       :ok   -> :passed
       error -> {:failed, error, module, name}
     end
   end
 
-  def exec(module, name, args, parent) do
+  defp exec(module, name, args, parent) do
     result = apply(module, name, args)
     send parent, expand(result)
     Process.exit(self(), :kill)
   end
 
-  def expand(:ok), do: :ok
-  def expand(error) do
+  defp expand(:ok), do: :ok
+  defp expand(error) do
     {file, line} = System.stacktrace
       |> Enum.drop_while(&in_ex_unit?/1)
       |> List.first

--- a/lib/execute.ex
+++ b/lib/execute.ex
@@ -1,0 +1,48 @@
+defmodule Execute do
+  def run_module(module) do
+    run_until_failure(module, &run_koan/2)
+  end
+
+  def run_until_failure(module, callback) do
+    Enum.reduce_while(module.all_koans, :passed, fn(it, _acc) ->
+      result = callback.(module, it)
+      if result == :passed do
+        {:cont, :passed}
+      else
+        {:halt, result}
+      end
+    end)
+  end
+
+  def run_koan(module, name, args \\ []) do
+    parent = self()
+    spawn fn -> exec(module, name, args, parent) end
+    receive do
+      :ok   -> :passed
+      error -> {:failed, error, module, name}
+    end
+  end
+
+  def exec(module, name, args, parent) do
+    result = apply(module, name, args)
+    send parent, expand(result)
+    Process.exit(self(), :kill)
+  end
+
+  def expand(:ok), do: :ok
+  def expand(error) do
+    {file, line} = System.stacktrace
+      |> Enum.drop_while(&in_ex_unit?/1)
+      |> List.first
+      |> extract_file_and_line
+
+      %{error: error, file: file, line: line}
+  end
+
+  defp in_ex_unit?({ExUnit.Assertions, _, _, _}), do: true
+  defp in_ex_unit?(_), do: false
+
+  defp extract_file_and_line({_, _, _, [file: file, line: line]}) do
+   {file, line}
+  end
+end

--- a/lib/runner.ex
+++ b/lib/runner.ex
@@ -33,11 +33,16 @@ defmodule Runner do
   end
 
   def run_module(module) do
-    Display.considering(module)
-    case Execute.run_module(module) do
-        {:failed, error, module, name} -> Display.show_failure(error, module, name)
-                                          :failed
-        _ -> :passed
-    end
+    module
+    |> Display.considering
+    |> Execute.run_module
+    |> display
+
   end
+
+  defp display({:failed, error, module, name}) do
+    Display.show_failure(error, module, name)
+    :failed
+  end
+  defp display(_), do: :passed
 end

--- a/lib/runner.ex
+++ b/lib/runner.ex
@@ -14,25 +14,23 @@ defmodule Runner do
     Tasks,
   ]
 
-  def koan?(module) do
-    Enum.member?(@modules, module)
-  end
+  def koan?(koan), do: Enum.member?(@modules, koan)
 
   def run do
     Options.initial_koan
     |>run
   end
 
-  def run(start_module) when start_module in @modules do
+  def run(start_module) when start_module in @modules, do: run(start_module, @modules)
+  def run(start_module), do: Display.invalid_koan(start_module, @modules)
+
+  def run(start_module, modules) do
     Display.clear_screen()
 
-    start_idx = Enum.find_index(@modules, &(&1 == start_module))
-
-    @modules
-    |> Enum.drop(start_idx)
+    modules
+    |> Enum.drop_while( &(&1 != start_module))
     |> Enum.take_while( &(run_module(&1) == :passed))
   end
-  def run(koan), do: Display.invalid_koan(koan, @modules)
 
   def run_module(module) do
     Display.considering(module)
@@ -64,7 +62,22 @@ defmodule Runner do
 
   def exec(module, name, args, parent) do
     result = apply(module, name, args)
-    send parent, result
+    send parent, expand(result)
     Process.exit(self(), :kill)
   end
+
+  def expand(:ok), do: :ok
+  def expand(error) do
+    {file, line} = System.stacktrace
+      |> Enum.drop_while(&in_ex_unit?/1)
+      |> List.first
+      |> extract_file_and_line
+
+      %{error: error, file: file, line: line}
+  end
+
+  defp in_ex_unit?({ExUnit.Assertions, _, _, _}), do: true
+  defp in_ex_unit?(_), do: false
+
+  defp extract_file_and_line({_, _, _, [file: file, line: line]}), do: {file, line}
 end

--- a/test/executor_test.exs
+++ b/test/executor_test.exs
@@ -1,4 +1,4 @@
-defmodule RunnerTest do
+defmodule ExecuteTest do
   use ExUnit.Case
 
   test "passes a koan" do

--- a/test/executor_test.exs
+++ b/test/executor_test.exs
@@ -1,0 +1,13 @@
+defmodule RunnerTest do
+  use ExUnit.Case
+
+  test "passes a koan" do
+    assert :passed == Execute.run_module(PassingKoan)
+  end
+
+  test "stops at the first failing koan" do
+    {:failed, %{error: _, file: file, line: line}, SampleKoan, _name} = Execute.run_module(SampleKoan)
+    assert file == 'test/support/sample_koan.ex'
+    assert line == 5
+  end
+end

--- a/test/koans_harness_test.exs
+++ b/test/koans_harness_test.exs
@@ -232,6 +232,6 @@ defmodule KoansHarnessTest do
   end
 
   def run_all(pairs, module) do
-    Enum.map(pairs, fn ({koan, answer}) -> Runner.run_koan(module, koan, [answer]) end)
+    Enum.map(pairs, fn ({koan, answer}) -> Execute.run_koan(module, koan, [answer]) end)
   end
 end

--- a/test/support/passing_koan.ex
+++ b/test/support/passing_koan.ex
@@ -1,0 +1,7 @@
+defmodule PassingKoan do
+  use Koans
+
+  koan "hi there" do
+    assert 1 == 1
+  end
+end


### PR DESCRIPTION
This PR is necessary to build good Agents and Supervisior koans.
It changes the way we run koans from single process for all modules, to a individual process per _koan_.
That way, anything process that is started with a _link_ will be torn down after the koan.

It also splits _executing_ a koan from _running all koans_. The former has no dependencies, the latter depends on `Display` and `Options`.

A large chunk of credit goes to @marosluuce :+1: 

@ukutaht 
@Maikon 